### PR TITLE
simulators/ethereum/engine: Fix blob tx creation - add GasFee

### DIFF
--- a/simulators/ethereum/engine/suites/blobs/steps.go
+++ b/simulators/ethereum/engine/suites/blobs/steps.go
@@ -310,6 +310,7 @@ func (step SendBlobTransactions) Execute(t *BlobTestContext) error {
 			To:         &addr,
 			GasLimit:   100000,
 			GasTip:     step.BlobTransactionGasTipCap,
+			GasFee:     step.BlobTransactionGasFeeCap,
 			DataGasFee: step.BlobTransactionMaxDataGasCost,
 			BlobCount:  blobCountPerTx,
 			BlobID:     t.CurrentBlobID,


### PR DESCRIPTION
As I see here:
https://github.com/marioevz/hive/blob/engine-api-blobs/simulators/ethereum/engine/suites/blobs/tests.go#L245-L293
it is expected to be increasing for both, `GasTipCap` and `GasFeeCap`.

`GasFee` is not specified here:
https://github.com/marioevz/hive/blob/engine-api-blobs/simulators/ethereum/engine/suites/blobs/steps.go#L309-L316
so it has default value (30 Gwei) from here:
https://github.com/marioevz/hive/blob/engine-api-blobs/simulators/ethereum/engine/helper/helper.go#L692-L693
`GasFee` is not increasing and it is why nodes are not allowing transactions to replace

I tested this branch with Nethermind and in this form this test is passing